### PR TITLE
Page Menu: Problem with non english language

### DIFF
--- a/BootstrapMediaWiki.skin.php
+++ b/BootstrapMediaWiki.skin.php
@@ -424,26 +424,26 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 			);
 
 			if( 'page' == $which ) {
-				switch( $link['title'] ) {
-				case 'Page': $icon = 'file'; break;
-				case 'Discussion': $icon = 'comment'; break;
-				case 'Edit': $icon = 'pencil'; break;
-				case 'History': $icon = 'clock-o'; break;
-				case 'Delete': $icon = 'remove'; break;
-				case 'Move': $icon = 'arrows'; break;
-				case 'Protect': $icon = 'lock'; break;
-				case 'Watch': $icon = 'eye-open'; break;
-				case 'Unwatch': $icon = 'eye-slash'; break;
+				switch( $link['id'] ) {
+				case 'nstab-main': $icon = 'file'; break;
+				case 'talk': $icon = 'comment'; break;
+				case 'edit': $icon = 'pencil'; break;
+				case 'history': $icon = 'clock-o'; break;
+				case 'delete': $icon = 'remove'; break;
+				case 'move': $icon = 'arrows'; break;
+				case 'protect': $icon = 'lock'; break;
+				case 'watch': $icon = 'eye'; break;
+				case 'unwatch': $icon = 'eye-slash'; break;
 				}//end switch
 
 				$link['title'] = '<i class="fa fa-' . $icon . '"></i> ' . $link['title'];
 			} elseif( 'user' == $which ) {
-				switch( $link['title'] ) {
-				case 'My talk': $icon = 'comment'; break;
-				case 'My preferences': $icon = 'cog'; break;
-				case 'My watchlist': $icon = 'eye-close'; break;
-				case 'My contributions': $icon = 'list-alt'; break;
-				case 'Log out': $icon = 'off'; break;
+				switch( $link['id'] ) {
+				case 'mytalk': $icon = 'comment'; break;
+				case 'preferences': $icon = 'cog'; break;
+				case 'watchlist': $icon = 'eye'; break;
+				case 'mycontris': $icon = 'list-alt'; break;
+				case 'logout': $icon = 'power-off'; break;
 				default: $icon = 'user'; break;
 				}//end switch
 


### PR DESCRIPTION
Change the icon chooser to use ID instead of TITLE.
Because TITLE only works in english.
Changed the icon 'eye-open' and 'eye-close' for 'eye'.
Changed the icon 'off' for 'power-off'.

Signed-off-by: Josep Rius Font josepriusfont@gmail.com
