### PR TITLE
Switch from wfMsg to wfMessage

### DIFF
--- a/BootstrapMediaWiki.skin.php
+++ b/BootstrapMediaWiki.skin.php
@@ -144,7 +144,7 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 						?>
 						<ul class="nav navbar-nav navbar-right">
 							<li>
-							<?php echo Linker::linkKnown( SpecialPage::getTitleFor( 'Userlogin' ), wfMsg( 'login' ) ); ?>
+							<?php echo Linker::linkKnown( SpecialPage::getTitleFor( 'Userlogin' ), wfMessage( 'login' ) ); ?>
 							</li>
 						</ul>
 						<?php


### PR DESCRIPTION
Switch from wfMsg to wfMessage, as wfMsg is deprecated.

https://www.mediawiki.org/wiki/Manual:Messages_API#Help_with_replacing_deprecated_wfMsg.2A_functions

https://www.mediawiki.org/wiki/Topic:Tccakhq97grwav0i


PHP Fatal error:  Uncaught Error: Call to undefined function wfMsg() in /var/www/html/mediawiki/skins/bootstrap-mediawiki/BootstrapMediaWiki.skin.php:147\nStack trace:\n#0 /var/www/html/mediawiki/includes/skins/SkinTemplate.php(251): BootstrapMediaWikiTemplate->execute()\n#1 /var/www/html/mediawiki/includes/OutputPage.php(2388): SkinTemplate->outputPage()\n#2 /var/www/html/mediawiki/includes/exception/MWExceptionRenderer.php(135): OutputPage->output()\n#3 /var/www/html/mediawiki/includes/exception/MWExceptionRenderer.php(54): MWExceptionRenderer::reportHTML(Object(Error))\n#4 /var/www/html/mediawiki/includes/exception/MWExceptionHandler.php(75): MWExceptionRenderer::output(Object(Error), 2)\n#5 /var/www/html/mediawiki/includes/exception/MWExceptionHandler.php(149): MWExceptionHandler::report(Object(Error))\n#6 /var/www/html/mediawiki/includes/exception/MWExceptionHandler.php(121): MWExceptionHandler::handleException(Object(Error))\n#7 [internal function]: MWExceptionHandler::handleUncaughtException(Object(Error))\n#8 {main}\n  thrown in /var/www/html/mediawiki/skins/bootstrap-mediawiki/BootstrapMediaWiki.skin.php on line 147, referer: http://localhost/mediawiki/index.php/Main_Page