### PR TITLE
Removing the -n param

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ WATCHR ?= `which watchr`
 
 mediawiki: bootstrap
 	cat bootstrap/js/bootstrap.js js/jquery-dotimeout/jquery.ba-dotimeout.js js/behavior.js > js/site.js
-	uglifyjs -nc js/site.js > js/site.min.js
+	uglifyjs -c js/site.js > js/site.min.js
 
 bootstrap: 
 	rm -rf bootstrap


### PR DESCRIPTION
Looks like -n is removed from the latest uglifyjs, gives the error...
error: unknown option `-n'