### PR TITLE
Fixed dotimeout file path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ WATCHR ?= `which watchr`
 #
 
 mediawiki: bootstrap
-	cat bootstrap/js/bootstrap.js js/jquery-dotimeout/jquery.ba-dotimeout.js js/behavior.js > js/site.js
+	cat bootstrap/js/bootstrap.js js/jquery.ba-dotimeout.min.js js/behavior.js > js/site.js
 	uglifyjs -nc js/site.js > js/site.min.js
 
 bootstrap: 


### PR DESCRIPTION
fixed file path to match what is now in the repo

From...
js/jquery-dotimeout/jquery.ba-dotimeout.js
...to...
js/jquery.ba-dotimeout.min.js

This caused the error...
`cat: js/jquery.ba-dotimeout.js: No such file or directory
Makefile:14: recipe for target 'mediawiki' failed`

